### PR TITLE
Update base.rb for VirtualBox version 4.3

### DIFF
--- a/lib/vagrant-persistent-storage/providers/virtualbox/driver/base.rb
+++ b/lib/vagrant-persistent-storage/providers/virtualbox/driver/base.rb
@@ -6,7 +6,7 @@ module VagrantPlugins
       class Base
 
         def create_adapter
-          execute("storagectl", @uuid, "--name", "SATA Controller", "--sataportcount", "2")
+          execute("storagectl", @uuid, "--name", "SATA Controller", "--" + (@version.start_with?("4.3") ? "" : "sata") + "portcount", "2")
         end
 
         def create_storage(location, size)


### PR DESCRIPTION
With VirtualBox 4.3, the vboxmanage  `--sataportcount` option has been changed to plain old `--portcount`.  This change very simply checks if the version of VirtualBox is 4.3 (there didn't appear to be a way to do a `< 4.3` check) and adjusts the flag accordingly.
