### PR TITLE
Add config 'mountoptions'

### DIFF
--- a/lib/vagrant-persistent-storage/config.rb
+++ b/lib/vagrant-persistent-storage/config.rb
@@ -14,6 +14,7 @@ module VagrantPlugins
       attr_accessor :location
       attr_accessor :mountname
       attr_accessor :mountpoint
+      attr_accessor :mountoptions
       attr_accessor :diskdevice
       attr_accessor :filesystem
       attr_accessor :volgroupname
@@ -36,6 +37,7 @@ module VagrantPlugins
         @location = UNSET_VALUE
         @mountname = UNSET_VALUE
         @mountpoint = UNSET_VALUE
+        @mountoptions = UNSET_VALUE
         @diskdevice = UNSET_VALUE
         @filesystem = UNSET_VALUE
         @volgroupname = UNSET_VALUE
@@ -52,6 +54,7 @@ module VagrantPlugins
         @location = 0 if @location == UNSET_VALUE
         @mountname = 0 if @mountname == UNSET_VALUE
         @mountpoint = 0 if @mountpoint == UNSET_VALUE
+        @mountoptions = 0 if @mountoptions == UNSET_VALUE
         @diskdevice = 0 if @diskdevice == UNSET_VALUE
         @filesystem = 0 if @filesystem == UNSET_VALUE
         @volgroupname = 0 if @volgroupname == UNSET_VALUE

--- a/lib/vagrant-persistent-storage/manage_storage.rb
+++ b/lib/vagrant-persistent-storage/manage_storage.rb
@@ -9,6 +9,7 @@ module VagrantPlugins
       def populate_template(m)
         mnt_name = m.config.persistent_storage.mountname
         mnt_point = m.config.persistent_storage.mountpoint
+        mnt_options = m.config.persistent_storage.mountoptions
         vg_name = m.config.persistent_storage.volgroupname
         disk_dev = m.config.persistent_storage.diskdevice
         fs_type = m.config.persistent_storage.filesystem
@@ -20,6 +21,7 @@ module VagrantPlugins
         vg_name = 'vps' unless vg_name != 0
         disk_dev = '/dev/sdb' unless disk_dev != 0
         mnt_name = 'vps' unless mnt_name != 0
+        mnt_options = ['defaults'] unless mnt_options != 0
         fs_type = 'ext3' unless fs_type != 0
         if use_lvm
           device = "/dev/#{vg_name}-vg1/#{mnt_name}"
@@ -57,7 +59,7 @@ echo "#{fs_type} creation return:  $?" >> disk_operation_log.txt
 # Create mountpoint #{mnt_point}
 [ -d #{mnt_point} ] || mkdir -p #{mnt_point}
 # Update fstab with new mountpoint name
-[[ `grep -i #{device} /etc/fstab` ]] || echo #{device} #{mnt_point} #{fs_type} defaults 0 0 >> /etc/fstab
+[[ `grep -i #{device} /etc/fstab` ]] || echo #{device} #{mnt_point} #{fs_type} #{mnt_options.join(',')} 0 0 >> /etc/fstab
 echo "fstab update returned:  $?" >> disk_operation_log.txt
 # Finally, mount the partition
 [[ `mount | grep #{mnt_point}` ]] || mount #{mnt_point}


### PR DESCRIPTION
Hi ! 

This commit add config `mountoptions` to be able to change mount options `defaults` to any value.
## Sample Usage

``` ruby
config.persistent_storage.enabled      = true
config.persistent_storage.location     = "./tmp/sourcehdd.vdi"
config.persistent_storage.size         = 500
config.persistent_storage.mountname    = 'xfs'
config.persistent_storage.filesystem   = 'xfs'
config.persistent_storage.mountpoint   = '/mnt/xfs'
config.persistent_storage.mountoptions = ['defaults', 'prjquota']
```

```
[vagrant@vagrant-centos65 ~]$ cat /etc/fstab 

#
# /etc/fstab
# Created by anaconda on Thu Dec  5 14:15:50 2013
#
# Accessible filesystems, by reference, are maintained under '/dev/disk'
# See man pages fstab(5), findfs(8), mount(8) and/or blkid(8) for more info
#
UUID=ecd27adf-074b-4511-8cee-4a08a4620a4f /                       ext4    defaults        0 0
UUID=6a229de0-2206-4e10-b1a2-496ea60ec30e swap                    swap    defaults        0 0
tmpfs                   /dev/shm                tmpfs   defaults        0 0
devpts                  /dev/pts                devpts  gid=5,mode=620  0 0
sysfs                   /sys                    sysfs   defaults        0 0
proc                    /proc                   proc    defaults        0 0
/dev/vps-vg1/xfs /mnt/xfs xfs defaults,prjquota 0 0
```
