### PR TITLE
reading persistent_storage may return a nil object so updated the check ...

### DIFF
--- a/lib/vagrant-persistent-storage/providers/virtualbox/driver/base.rb
+++ b/lib/vagrant-persistent-storage/providers/virtualbox/driver/base.rb
@@ -25,7 +25,7 @@ module VagrantPlugins
 
         def detach_storage(location)
           persistent_storage = read_persistent_storage()
-          if location and persistent_storage != "none" and identical_files(persistent_storage, location)
+          if location and persistent_storage and persistent_storage != "none" and identical_files(persistent_storage, location)
             execute("storageattach", @uuid, "--storagectl", get_controller_name, "--port", "1", "--device", "0", "--type", "hdd", "--medium", "none")
           end
         end


### PR DESCRIPTION
...to prevent file comparison from failing.

Background: I ran into a case where read_persistent_storage() returns a nil object as the file path, so when the identical_files(persistent_storage, location) method executes, the Pathname.new(nil) call throws an exception.

So I've added a check well before that on the persistent_storage file name validation. Hope this is alright.
