### PR TITLE
Allow to halt a VM which doesn't have a persistent storage attached

### DIFF
--- a/lib/vagrant-persistent-storage/providers/virtualbox/driver/base.rb
+++ b/lib/vagrant-persistent-storage/providers/virtualbox/driver/base.rb
@@ -25,7 +25,7 @@ module VagrantPlugins
 
         def detach_storage(location)
           persistent_storage = read_persistent_storage()
-          if location and persistent_storage != "none" and identical_files(persistent_storage, location)
+          if location and persistent_storage and persistent_storage != "none" and identical_files(persistent_storage, location)
             execute("storageattach", @uuid, "--storagectl", get_controller_name, "--port", "1", "--device", "0", "--type", "hdd", "--medium", "none")
           end
         end


### PR DESCRIPTION
If you already have a VM running, then you install `vagrant-persistent-storage` and add a configuration to your `Vagrantfile`, you are no longer able to stop the VM.

```
17:39:29] ==> aws: Attempting graceful shutdown of VM...
[17:39:50] ==> aws: ** Detaching persistent storage **
[17:40:01] /xxx/.vagrant.d/gems/gems/vagrant-persistent-storage-0.0.13/lib/vagrant-persistent-storage/providers/virtualbox/driver/base.rb:46:in `initialize': no implicit conversion of nil into String (TypeError)
    from /xxx/.vagrant.d/gems/gems/vagrant-persistent-storage-0.0.13/lib/vagrant-persistent-storage/providers/virtualbox/driver/base.rb:46:in `new'
    from /xxx/.vagrant.d/gems/gems/vagrant-persistent-storage-0.0.13/lib/vagrant-persistent-storage/providers/virtualbox/driver/base.rb:46:in `identical_files'
    from /xxx/.vagrant.d/gems/gems/vagrant-persistent-storage-0.0.13/lib/vagrant-persistent-storage/providers/virtualbox/driver/base.rb:30:in `detach_storage'
    from /xxx/.vagrant.d/gems/gems/vagrant-persistent-storage-0.0.13/lib/vagrant-persistent-storage/action/detach_storage.rb:25:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
```
