### PR TITLE
Added support for Windows Guest VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ The disk is initialized and added to it's own volume group as specfied in the co
 this defaults to 'vagrant'. An ext4 filesystem is created and the disk mounted appropriately,
 with entries added to fstab ... subsequent runs will mount this disk with the options specified
 
+## Windows Guests
+
+Windows Guests must use the WinRM communicator by setting `vm.communicator = 'winrm'`.  An additional option is provided to 
+allow you to set the drive letter using:
+
+```
+config.persistent_storage.drive_letter = 'Z'
+```
+
+Options that are irrelevent to Windows are ignored, such as `mountname`, `filesystem`, `mountpoint` and `volgroupname`.
+
 ## Troubleshooting
 
 If your box are not using LVM you must set `config.persistent_storage.use_lvm = false`.

--- a/lib/vagrant-persistent-storage/config.rb
+++ b/lib/vagrant-persistent-storage/config.rb
@@ -18,6 +18,7 @@ module VagrantPlugins
       attr_accessor :diskdevice
       attr_accessor :filesystem
       attr_accessor :volgroupname
+	  attr_accessor :drive_letter
 
       alias_method :create?, :create
       alias_method :mount?, :mount
@@ -41,6 +42,7 @@ module VagrantPlugins
         @diskdevice = UNSET_VALUE
         @filesystem = UNSET_VALUE
         @volgroupname = UNSET_VALUE
+		@drive_letter = UNSET_VALUE
       end
 
       def finalize!
@@ -58,6 +60,7 @@ module VagrantPlugins
         @diskdevice = 0 if @diskdevice == UNSET_VALUE
         @filesystem = 0 if @filesystem == UNSET_VALUE
         @volgroupname = 0 if @volgroupname == UNSET_VALUE
+		@drive_letter = 0 if @drive_letter == UNSET_VALUE
       end
 
       def validate(machine)
@@ -113,7 +116,7 @@ module VagrantPlugins
             :is_class   => volgroupname.class.to_s,
           })
         end
-        
+
         mount_point_path = Pathname.new("#{machine.config.persistent_storage.location}")
         if ! mount_point_path.absolute?
           errors << I18n.t('vagrant_persistent_storage.config.not_a_path', {

--- a/sample-win-vm/Vagrantfile
+++ b/sample-win-vm/Vagrantfile
@@ -1,0 +1,22 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "myWindowsBox"
+
+  # These are required for Windows machines running under vagrant
+  config.vm.communicator = "winrm"
+  config.winrm.username = "Administrator"
+  config.winrm.password = "Password!"
+
+  # configure a persistent storage for mysql data
+  config.persistent_storage.enabled = true
+  config.persistent_storage.location = "virtualdrive.vdi"
+  config.persistent_storage.size = 5000
+
+end


### PR DESCRIPTION
This adds support for enabling persistent storage on Windows Guests.  It auto-detects based on whether WinRM is used or not.  This is the same method that the shell provisioner in Vagrant uses.
