### PR TITLE
Fix sfdisk version match pattern to not require two dots (.)

### DIFF
--- a/lib/vagrant-persistent-storage/manage_storage.rb
+++ b/lib/vagrant-persistent-storage/manage_storage.rb
@@ -58,7 +58,7 @@ module VagrantPlugins
         disk_operations_template = ERB.new <<-EOF
 #!/bin/bash
 # fdisk the disk if it's not a block device already:
-[[ $("sfdisk" --version) =~ ([0-9][.][0-9.]*[.][0-9.]*) ]] && version="${BASH_REMATCH[1]}"
+[[ $("sfdisk" --version) =~ ([0-9][.][0-9.]*[0-9.]*) ]] && version="${BASH_REMATCH[1]}"
 if ! awk -v ver="$version" 'BEGIN { if (ver < 2.26 ) exit 1; }'; then
 	[ -b #{disk_dev}1 ] || echo 0,,8e | sfdisk #{disk_dev}
 else


### PR DESCRIPTION
 - The version does not always contain a patch level.
 - This makes it work on Fedora 23 -
  - # sfdisk --version
  - sfdisk from util-linux 2.28