### PR TITLE
Removes appended '-vg1' to vg_name variable

### DIFF
--- a/lib/vagrant-persistent-storage/manage_storage.rb
+++ b/lib/vagrant-persistent-storage/manage_storage.rb
@@ -32,7 +32,7 @@ module VagrantPlugins
         mnt_options = ['defaults'] unless mnt_options != 0
         fs_type = 'ext3' unless fs_type != 0
         if use_lvm
-          device = "/dev/#{vg_name}-vg1/#{mnt_name}"
+          device = "/dev/#{vg_name}/#{mnt_name}"
         else
           device = "#{disk_dev}1"
         end
@@ -71,13 +71,13 @@ echo "fdisk returned:  $?" >> disk_operation_log.txt
 [[ `pvs #{disk_dev}1` ]] || pvcreate #{disk_dev}1
 echo "pvcreate returned:  $?" >> disk_operation_log.txt
 # Create the volume group if it doesn't already exist:
-[[ `vgs #{vg_name}-vg1` ]] || vgcreate #{vg_name}-vg1 #{disk_dev}1
+[[ `vgs #{vg_name}` ]] || vgcreate #{vg_name} #{disk_dev}1
 echo "vgcreate returned:  $?" >> disk_operation_log.txt
 # Create the logical volume if it doesn't already exist:
-[[ `lvs #{vg_name}-vg1 | grep #{mnt_name}` ]] || lvcreate -l 100%FREE -n #{mnt_name} #{vg_name}-vg1
+[[ `lvs #{vg_name} | grep #{mnt_name}` ]] || lvcreate -l 100%FREE -n #{mnt_name} #{vg_name}
 echo "lvcreate returned:  $?" >> disk_operation_log.txt
 # Activate the volume group if it's inactive:
-[[ `lvs #{vg_name}-vg1 --noheadings --nameprefixes | grep LVM2_LV_ATTR | grep "wi\-a"` ]] || vgchange #{vg_name}-vg1 -a y
+[[ `lvs #{vg_name} --noheadings --nameprefixes | grep LVM2_LV_ATTR | grep "wi\-a"` ]] || vgchange #{vg_name} -a y
 echo "vg activation returned:  $?" >> disk_operation_log.txt
 <% end %>
 


### PR DESCRIPTION
The appended `-vg1` to the `vg_name` variable throws off the expected naming of the volume group WHEN volgroupname is specified in the Vagrantfile.

For example:

```
       node.persistent_storage.enabled = true
       node.persistent_storage.location = mongovol
       node.persistent_storage.size = 2048
       node.persistent_storage.mountname = 'mongovol'
       node.persistent_storage.filesystem = 'ext4'
       node.persistent_storage.mountpoint = '/opt/mongo'
       node.persistent_storage.volgroupname = 'mongovg'
```

I'd expect the corresponding LVM config to create:  `/dev/mapper/mongovg-mongovol`

When using tools like puppet that utilize the mount resource type, the hard coded append can throw off the desired state.  Though things like Hiera can be used to change the value inside of a vagrant development environment, it feels like unnecessary complexity when these environmental difference don't pertain upstream.