### PR TITLE
Partition should not be  8E when use_lvm is set to false

### DIFF
--- a/lib/vagrant-persistent-storage/config.rb
+++ b/lib/vagrant-persistent-storage/config.rb
@@ -18,7 +18,8 @@ module VagrantPlugins
       attr_accessor :diskdevice
       attr_accessor :filesystem
       attr_accessor :volgroupname
-	  attr_accessor :drive_letter
+      attr_accessor :drive_letter
+      attr_accessor :part_type_code
 
       alias_method :create?, :create
       alias_method :mount?, :mount
@@ -42,7 +43,8 @@ module VagrantPlugins
         @diskdevice = UNSET_VALUE
         @filesystem = UNSET_VALUE
         @volgroupname = UNSET_VALUE
-		@drive_letter = UNSET_VALUE
+        @drive_letter = UNSET_VALUE
+        @part_type_code = UNSET_VALUE
       end
 
       def finalize!
@@ -60,7 +62,8 @@ module VagrantPlugins
         @diskdevice = 0 if @diskdevice == UNSET_VALUE
         @filesystem = 0 if @filesystem == UNSET_VALUE
         @volgroupname = 0 if @volgroupname == UNSET_VALUE
-		@drive_letter = 0 if @drive_letter == UNSET_VALUE
+        @drive_letter = 0 if @drive_letter == UNSET_VALUE
+        @part_type_code = "8e" if @part_type_code == UNSET_VALUE
       end
 
       def validate(machine)
@@ -108,6 +111,12 @@ module VagrantPlugins
           errors << I18n.t('vagrant_persistent_storage.config.not_a_string', {
             :config_key => 'persistent_storage.filesystem',
             :is_class   => filesystem.class.to_s,
+          })
+        end
+	if !machine.config.persistent_storage.volgroupname.part_type_code?(String)
+          errors << I18n.t('vagrant_persistent_storage.config.not_a_string', {
+            :config_key => 'persistent_storage.part_type_code',
+            :is_class   => volgroupname.class.to_s,
           })
         end
         if !machine.config.persistent_storage.volgroupname.kind_of?(String)

--- a/lib/vagrant-persistent-storage/manage_storage.rb
+++ b/lib/vagrant-persistent-storage/manage_storage.rb
@@ -16,6 +16,7 @@ module VagrantPlugins
         use_lvm = m.config.persistent_storage.use_lvm
         mount = m.config.persistent_storage.mount
         format = m.config.persistent_storage.format
+	part_type_code = m.config.persistent_storage.part_type_code
 
 		## windows filesystem options
 		drive_letter = m.config.persistent_storage.drive_letter
@@ -60,9 +61,9 @@ module VagrantPlugins
 # fdisk the disk if it's not a block device already:
 [[ $("sfdisk" --version) =~ ([0-9][.][0-9.]*[0-9.]*) ]] && version="${BASH_REMATCH[1]}"
 if ! awk -v ver="$version" 'BEGIN { if (ver < 2.26 ) exit 1; }'; then
-	[ -b #{disk_dev}1 ] || echo 0,,8e | sfdisk #{disk_dev}
+	[ -b #{disk_dev}1 ] || echo 0,,#{part_type_code} | sfdisk #{disk_dev}
 else
-	[ -b #{disk_dev}1 ] || echo ,,8e | sfdisk #{disk_dev}
+	[ -b #{disk_dev}1 ] || echo ,,#{part_type_code} | sfdisk #{disk_dev}
 fi
 echo "fdisk returned:  $?" >> disk_operation_log.txt
 


### PR DESCRIPTION
Hi,

When trying to use your plugin to add a swap disk to a VM i realized that the type of the volume was always LVM event when using a config like that :

```
config.persistent_storage.enabled = true
config.persistent_storage.create = true
config.persistent_storage.use_lvm = false
config.persistent_storage.format = false
config.persistent_storage.mount = false
config.persistent_storage.location = "./swap.vdi"
config.persistent_storage.size = 4096
config.persistent_storage.filesystem = 'swap'
```

The proposed MR should fix this with the addition of the following :
```
config.persistent_storage.part_type_code = '82'
```

Note that the format could not be completed since mkfs.swap doesnt exist (but mkswap does). But this is another story...
