### PR TITLE
bash 3.1 compatible, fix #63

### DIFF
--- a/lib/vagrant-persistent-storage/manage_storage.rb
+++ b/lib/vagrant-persistent-storage/manage_storage.rb
@@ -58,7 +58,7 @@ module VagrantPlugins
         disk_operations_template = ERB.new <<-EOF
 #!/bin/bash
 # fdisk the disk if it's not a block device already:
-[[ $("sfdisk" --version) =~ ([0-9][.][0-9.]*[0-9.]*) ]] && version="${BASH_REMATCH[1]}"
+re='[0-9][.][0-9.]*[0-9.]*'; [[ $(sfdisk --version) =~ $re ]] && version="${BASH_REMATCH}"
 if ! awk -v ver="$version" 'BEGIN { if (ver < 2.26 ) exit 1; }'; then
 	[ -b #{disk_dev}1 ] || echo 0,,8e | sfdisk #{disk_dev}
 else


### PR DESCRIPTION
Fix the error #63 in bash 3.1:

> /tmp/disk_operations_data.sh: line 3: unexpected argument (' to conditional binary operator /tmp/disk_operations_data.sh: line 3: syntax error near(['
> /tmp/disk_operations_data.sh: line 3: `[[ $("sfdisk" --version) =~ ([0-9][.][0-9.][0-9.]) ]] && version="${BASH_REMATCH[1]}"'

Store regular expression into variable, before us it.