### PR TITLE
Make Partitioning Optional and Fix Configuration Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ config.persistent_storage.drive_letter = 'Z'
 
 Options that are irrelevent to Windows are ignored, such as `mountname`, `filesystem`, `mountpoint` and `volgroupname`.
 
-
 ## How Is The Storage Created?
 
 Based on the configuration provided, during a `vagrant up` a bash script is generated and uploaded to `/tmp/disk_operations_#{mnt_name}.sh` (Linux) or `disk_operations_#{mnt_name}.ps1` (Windows).  If the box has not been previously provisioned the script is executed on a `vagrant up`.  To force the scrip to be executed again you can run `vagrant provision` or if you have halted the box, `vagrant up --provision`.

--- a/README.md
+++ b/README.md
@@ -34,28 +34,39 @@ config.persistent_storage.mountoptions = ['defaults', 'prjquota']
 ```
 
 Device defaults to `/dev/sdb`. For boxes with multiple disks, make sure you increment the drive:
-```
+```ruby
 config.persistent_storage.diskdevice = '/dev/sdc'
 ```
 
+If you are using LVM and you would prefer to use the disk rather than a partition, you can set the following configuration:
+```ruby
+config.persistent_storage.partition = false
+```
+
 Every `vagrant up` will attach this file as hard disk to the guest machine.
-An `vagrant destroy` will detach the storage to avoid deletion of the storage by vagrant.
+A `vagrant destroy` will detach the storage to avoid deletion of the storage by vagrant.
 A `vagrant destroy` generally destroys all attached drives. See [VBoxMange unregistervm --delete option][vboxmanage_delete].
 
 The disk is initialized and added to it's own volume group as specfied in the config; 
 this defaults to 'vagrant'. An ext4 filesystem is created and the disk mounted appropriately,
-with entries added to fstab ... subsequent runs will mount this disk with the options specified
+with entries added to fstab ... subsequent runs will mount this disk with the options specified.
 
 ## Windows Guests
 
 Windows Guests must use the WinRM communicator by setting `vm.communicator = 'winrm'`.  An additional option is provided to 
 allow you to set the drive letter using:
 
-```
+```ruby
 config.persistent_storage.drive_letter = 'Z'
 ```
 
 Options that are irrelevent to Windows are ignored, such as `mountname`, `filesystem`, `mountpoint` and `volgroupname`.
+
+## How Is The Storage Created?
+
+Based on the configuration provided, during a `vagrant up` a bash script is generated and uploaded to `/tmp/disk_operations_#{mnt_name}.sh` (Linux) or `disk_operations_#{mnt_name}.ps1` (Windows).  If the box has not been previously provisioned the script is executed on a `vagrant up`.  To force the scrip to be executed again you can run `vagrant provision` or if you have halted the box, `vagrant up --provision`.
+
+The outcome of the script being run is placed in the home drive of the vagrant user in a file called `disk_operation_log.txt`.
 
 ## Troubleshooting
 

--- a/lib/vagrant-persistent-storage/config.rb
+++ b/lib/vagrant-persistent-storage/config.rb
@@ -15,6 +15,7 @@ module VagrantPlugins
       attr_accessor :mountname
       attr_accessor :mountpoint
       attr_accessor :mountoptions
+      attr_accessor :partition
       attr_accessor :diskdevice
       attr_accessor :filesystem
       attr_accessor :volgroupname
@@ -25,6 +26,7 @@ module VagrantPlugins
       alias_method :manage?, :manage
       alias_method :format?, :format
       alias_method :use_lvm?, :use_lvm
+      alias_method :partition?, :partition
       alias_method :enabled?, :enabled
 
       def initialize
@@ -35,6 +37,7 @@ module VagrantPlugins
         @format = true
         @use_lvm = true
         @enabled = false
+        @partition = true
         @location = UNSET_VALUE
         @mountname = UNSET_VALUE
         @mountpoint = UNSET_VALUE
@@ -52,30 +55,32 @@ module VagrantPlugins
         @manage = true if @manage == UNSET_VALUE
         @format = true if @format == UNSET_VALUE
         @use_lvm = true if @use_lvm == UNSET_VALUE
+        @partition = true if @partition == UNSET_VALUE
         @enabled = false if @enabled == UNSET_VALUE
-        @location = 0 if @location == UNSET_VALUE
-        @mountname = 0 if @mountname == UNSET_VALUE
-        @mountpoint = 0 if @mountpoint == UNSET_VALUE
-        @mountoptions = 0 if @mountoptions == UNSET_VALUE
-        @diskdevice = 0 if @diskdevice == UNSET_VALUE
-        @filesystem = 0 if @filesystem == UNSET_VALUE
-        @volgroupname = 0 if @volgroupname == UNSET_VALUE
+        @location = "" if @location == UNSET_VALUE
+        @mountname = "" if @mountname == UNSET_VALUE
+        @mountpoint = "" if @mountpoint == UNSET_VALUE
+        @mountoptions = [] if @mountoptions == UNSET_VALUE
+        @diskdevice = "" if @diskdevice == UNSET_VALUE
+        @filesystem = "" if @filesystem == UNSET_VALUE
+        @volgroupname = "" if @volgroupname == UNSET_VALUE
 		@drive_letter = 0 if @drive_letter == UNSET_VALUE
       end
 
       def validate(machine)
-        errors = []
+        errors = _detected_errors
 
         errors << validate_bool('persistent_storage.create', @create)
         errors << validate_bool('persistent_storage.mount', @mount)
-        errors << validate_bool('persistent_storage.mount', @manage)
-        errors << validate_bool('persistent_storage.mount', @format)
-        errors << validate_bool('persistent_storage.mount', @use_lvm)
-        errors << validate_bool('persistent_storage.mount', @enabled)
+        errors << validate_bool('persistent_storage.manage', @manage)
+        errors << validate_bool('persistent_storage.format', @format)
+        errors << validate_bool('persistent_storage.use_lvm', @use_lvm)
+        errors << validate_bool('persistent_storage.enabled', @enabled)
+        errors << validate_bool('persistent_storage.partition', @partition)
         errors.compact!
 
-        if !machine.config.persistent_storage.size.kind_of?(String)
-          errors << I18n.t('vagrant_persistent_storage.config.not_a_string', {
+        if !machine.config.persistent_storage.size.kind_of?(Fixnum)
+          errors << I18n.t('vagrant_persistent_storage.config.not_a_number', {
             :config_key => 'persistent_storage.size',
             :is_class   => size.class.to_s,
           })
@@ -118,19 +123,21 @@ module VagrantPlugins
         end
 
         mount_point_path = Pathname.new("#{machine.config.persistent_storage.location}")
-        if ! mount_point_path.absolute?
+        if ! (mount_point_path.absolute? || mount_point_path.relative?)
           errors << I18n.t('vagrant_persistent_storage.config.not_a_path', {
             :config_key => 'persistent_storage.location',
             :is_path   => location.class.to_s,
           })
         end
 
-        { 'Persistent Storage configuration' => errors }
-
         if ! File.exists?@location.to_s and ! @create == "true"
-            return { "location" => ["file doesn't exist, and create set to false"] }
+          errors << I18n.t('vagrant_persistent_storage.config.no_create_and_missing', {
+            :config_key => 'persistent_storage.create',
+            :is_path   => location.class.to_s,
+          })       
         end
-        {}
+
+        { 'Persistent Storage configuration' => errors }
       end
 
       private

--- a/lib/vagrant-persistent-storage/manage_storage.rb
+++ b/lib/vagrant-persistent-storage/manage_storage.rb
@@ -60,11 +60,6 @@ module VagrantPlugins
 		## shell script to format disk, create/manage LVM, mount disk
         disk_operations_template = ERB.new <<-EOF
 #!/bin/bash
-# partition == #{partition}
-# use_lvm == #{use_lvm}
-# format == #{format}
-
-
 <% if partition == true %>
 # fdisk the disk if it's not a block device already:
 re='[0-9][.][0-9.]*[0-9.]*'; [[ $(sfdisk --version) =~ $re ]] && version="${BASH_REMATCH}"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -9,4 +9,7 @@ en:
       manage_storage: "** Managing persistent storage **"
     config:
       not_a_bool: "A value for %{config_key} can only be true or false, not type '%{value}'"
-      not_an_array_or_string: "A value for %{config_key} must be an Array or String, not type '%{is_class}'"
+      not_an_array_or_string: "A value for %{config_key} must be an Array or String, not type '%{value}'"
+      not_a_string: "A value for %{config_key} must be a String, not type '%{value}'"
+      not_a_path: "A value for %{config_key} must be resolveable as a path"
+      not_a_number: "A value for %{config_key} must be a number, not type '%{value}'"


### PR DESCRIPTION
Hi,

Firstly, thanks for the work on this!  This PR is aimed at providing the ability to specify whether we use partitioning or not.  It is *very* similar to https://github.com/kusnier/vagrant-persistent-storage/pull/65

Differences:
1. I had some problems with the implementation on 65 regarding turning off partitioning reducing the set of operations carried out to the extent that the plugin did not function as required.
2. Issues with the resultant disk devices being indexed incorrectly.

Also had a go at validating the configuration, as it appeared that this was not being done before, resulting in some confusion as to what settings were and were not being applied.

Also added some additional information and clarification to the readme.

Look forward to your feedback!

Thanks,

Ben