### PR TITLE
Fix issues with partition option and defaulting of config.  Added an easier automated test approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,28 +34,39 @@ config.persistent_storage.mountoptions = ['defaults', 'prjquota']
 ```
 
 Device defaults to `/dev/sdb`. For boxes with multiple disks, make sure you increment the drive:
-```
+```ruby
 config.persistent_storage.diskdevice = '/dev/sdc'
 ```
 
+If you are using LVM and you would prefer to use the disk rather than a partition, you can set the following configuration:
+```ruby
+config.persistent_storage.partition = false
+```
+
 Every `vagrant up` will attach this file as hard disk to the guest machine.
-An `vagrant destroy` will detach the storage to avoid deletion of the storage by vagrant.
+A `vagrant destroy` will detach the storage to avoid deletion of the storage by vagrant.
 A `vagrant destroy` generally destroys all attached drives. See [VBoxMange unregistervm --delete option][vboxmanage_delete].
 
 The disk is initialized and added to it's own volume group as specfied in the config; 
 this defaults to 'vagrant'. An ext4 filesystem is created and the disk mounted appropriately,
-with entries added to fstab ... subsequent runs will mount this disk with the options specified
+with entries added to fstab ... subsequent runs will mount this disk with the options specified.
 
 ## Windows Guests
 
 Windows Guests must use the WinRM communicator by setting `vm.communicator = 'winrm'`.  An additional option is provided to 
 allow you to set the drive letter using:
 
-```
+```ruby
 config.persistent_storage.drive_letter = 'Z'
 ```
 
 Options that are irrelevent to Windows are ignored, such as `mountname`, `filesystem`, `mountpoint` and `volgroupname`.
+
+## How Is The Storage Created?
+
+Based on the configuration provided, during a `vagrant up` a bash script is generated and uploaded to `/tmp/disk_operations_#{mnt_name}.sh` (Linux) or `disk_operations_#{mnt_name}.ps1` (Windows).  If the box has not been previously provisioned the script is executed on a `vagrant up`.  To force the scrip to be executed again you can run `vagrant provision` or if you have halted the box, `vagrant up --provision`.
+
+The outcome of the script being run is placed in the home drive of the vagrant user in a file called `disk_operation_log.txt`.
 
 ## Optional settings
 

--- a/lib/vagrant-persistent-storage/config.rb
+++ b/lib/vagrant-persistent-storage/config.rb
@@ -118,6 +118,12 @@ module VagrantPlugins
             :is_class   => filesystem.class.to_s,
           })
         end
+        if !machine.config.persistent_storage.volgroupname.part_type_code?(String)
+           errors << I18n.t('vagrant_persistent_storage.config.not_a_string', {
+             :config_key => 'persistent_storage.part_type_code',
+             :is_class   => volgroupname.class.to_s,
+           })
+        end
         if !machine.config.persistent_storage.volgroupname.kind_of?(String)
           errors << I18n.t('vagrant_persistent_storage.config.not_a_string', {
             :config_key => 'persistent_storage.volgroupname',

--- a/lib/vagrant-persistent-storage/config.rb
+++ b/lib/vagrant-persistent-storage/config.rb
@@ -15,6 +15,7 @@ module VagrantPlugins
       attr_accessor :mountname
       attr_accessor :mountpoint
       attr_accessor :mountoptions
+      attr_accessor :partition
       attr_accessor :diskdevice
       attr_accessor :filesystem
       attr_accessor :volgroupname
@@ -26,6 +27,7 @@ module VagrantPlugins
       alias_method :manage?, :manage
       alias_method :format?, :format
       alias_method :use_lvm?, :use_lvm
+      alias_method :partition?, :partition
       alias_method :enabled?, :enabled
 
       def initialize
@@ -36,6 +38,7 @@ module VagrantPlugins
         @format = true
         @use_lvm = true
         @enabled = false
+        @partition = true
         @location = UNSET_VALUE
         @mountname = UNSET_VALUE
         @mountpoint = UNSET_VALUE
@@ -54,31 +57,33 @@ module VagrantPlugins
         @manage = true if @manage == UNSET_VALUE
         @format = true if @format == UNSET_VALUE
         @use_lvm = true if @use_lvm == UNSET_VALUE
+        @partition = true if @partition == UNSET_VALUE
         @enabled = false if @enabled == UNSET_VALUE
-        @location = 0 if @location == UNSET_VALUE
-        @mountname = 0 if @mountname == UNSET_VALUE
-        @mountpoint = 0 if @mountpoint == UNSET_VALUE
-        @mountoptions = 0 if @mountoptions == UNSET_VALUE
-        @diskdevice = 0 if @diskdevice == UNSET_VALUE
-        @filesystem = 0 if @filesystem == UNSET_VALUE
-        @volgroupname = 0 if @volgroupname == UNSET_VALUE
-        @drive_letter = 0 if @drive_letter == UNSET_VALUE
+        @location = "" if @location == UNSET_VALUE
+        @mountname = "" if @mountname == UNSET_VALUE
+        @mountpoint = "" if @mountpoint == UNSET_VALUE
+        @mountoptions = [] if @mountoptions == UNSET_VALUE
+        @diskdevice = "" if @diskdevice == UNSET_VALUE
+        @filesystem = "" if @filesystem == UNSET_VALUE
+        @volgroupname = "" if @volgroupname == UNSET_VALUE
+		@drive_letter = 0 if @drive_letter == UNSET_VALUE
         @part_type_code = "8e" if @part_type_code == UNSET_VALUE
       end
 
       def validate(machine)
-        errors = []
+        errors = _detected_errors
 
         errors << validate_bool('persistent_storage.create', @create)
         errors << validate_bool('persistent_storage.mount', @mount)
-        errors << validate_bool('persistent_storage.mount', @manage)
-        errors << validate_bool('persistent_storage.mount', @format)
-        errors << validate_bool('persistent_storage.mount', @use_lvm)
-        errors << validate_bool('persistent_storage.mount', @enabled)
+        errors << validate_bool('persistent_storage.manage', @manage)
+        errors << validate_bool('persistent_storage.format', @format)
+        errors << validate_bool('persistent_storage.use_lvm', @use_lvm)
+        errors << validate_bool('persistent_storage.enabled', @enabled)
+        errors << validate_bool('persistent_storage.partition', @partition)
         errors.compact!
 
-        if !machine.config.persistent_storage.size.kind_of?(String)
-          errors << I18n.t('vagrant_persistent_storage.config.not_a_string', {
+        if !machine.config.persistent_storage.size.kind_of?(Fixnum)
+          errors << I18n.t('vagrant_persistent_storage.config.not_a_number', {
             :config_key => 'persistent_storage.size',
             :is_class   => size.class.to_s,
           })
@@ -121,19 +126,21 @@ module VagrantPlugins
         end
 
         mount_point_path = Pathname.new("#{machine.config.persistent_storage.location}")
-        if ! mount_point_path.absolute?
+        if ! (mount_point_path.absolute? || mount_point_path.relative?)
           errors << I18n.t('vagrant_persistent_storage.config.not_a_path', {
             :config_key => 'persistent_storage.location',
             :is_path   => location.class.to_s,
           })
         end
 
-        { 'Persistent Storage configuration' => errors }
-
         if ! File.exists?@location.to_s and ! @create == "true"
-            return { "location" => ["file doesn't exist, and create set to false"] }
+          errors << I18n.t('vagrant_persistent_storage.config.no_create_and_missing', {
+            :config_key => 'persistent_storage.create',
+            :is_path   => location.class.to_s,
+          })       
         end
-        {}
+
+        { 'Persistent Storage configuration' => errors }
       end
 
       private

--- a/lib/vagrant-persistent-storage/config.rb
+++ b/lib/vagrant-persistent-storage/config.rb
@@ -118,12 +118,12 @@ module VagrantPlugins
             :is_class   => filesystem.class.to_s,
           })
         end
-        if !machine.config.persistent_storage.volgroupname.part_type_code?(String)
+        if !machine.config.persistent_storage.part_type_code.kind_of?(String)
            errors << I18n.t('vagrant_persistent_storage.config.not_a_string', {
              :config_key => 'persistent_storage.part_type_code',
              :is_class   => volgroupname.class.to_s,
            })
-        end
+         end
         if !machine.config.persistent_storage.volgroupname.kind_of?(String)
           errors << I18n.t('vagrant_persistent_storage.config.not_a_string', {
             :config_key => 'persistent_storage.volgroupname',

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -9,4 +9,8 @@ en:
       manage_storage: "** Managing persistent storage **"
     config:
       not_a_bool: "A value for %{config_key} can only be true or false, not type '%{value}'"
-      not_an_array_or_string: "A value for %{config_key} must be an Array or String, not type '%{is_class}'"
+      not_an_array_or_string: "A value for %{config_key} must be an Array or String, not type '%{value}'"
+      not_a_string: "A value for %{config_key} must be a String, not type '%{value}'"
+      not_a_path: "A value for %{config_key} must be resolveable as a path"
+      not_a_number: "A value for %{config_key} must be a number, not type '%{value}'"
+      no_create_and_missing: "File doesn't exist, and create set to false"

--- a/sample-vm/partition-false.vagrantfile
+++ b/sample-vm/partition-false.vagrantfile
@@ -1,0 +1,30 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "precise32"
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  #config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+
+  # configure a persistent storage for mysql data
+  config.persistent_storage.enabled = true
+  config.persistent_storage.location = "virtualdrive.vdi"
+  config.persistent_storage.size = 5000
+  config.persistent_storage.mountname = 'mysql'
+  config.persistent_storage.filesystem = 'ext4'
+  config.persistent_storage.mountpoint = '/var/lib/mysql'
+  config.persistent_storage.volgroupname = 'myvolgroup'
+  config.persistent_storage.partition = false
+
+  config.vm.provision "fix-no-tty", type: "shell" do |s|
+      s.privileged = false
+      s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
+    end
+  end

--- a/sample-vm/partition-true.vagrantfile
+++ b/sample-vm/partition-true.vagrantfile
@@ -22,4 +22,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.persistent_storage.mountpoint = '/var/lib/mysql'
   config.persistent_storage.volgroupname = 'myvolgroup'
 
-end
+  config.vm.provision "fix-no-tty", type: "shell" do |s|
+      s.privileged = false
+      s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
+    end
+  end

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+pushd sample-vm > /dev/null
+
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+        VBOXMANAGE=`which vboxmanage`
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+        VBOXMANAGE=`which vboxmanage`
+elif [[ "$OSTYPE" == "cygwin" ]]; then
+		VBOXMANAGE="/c/Program Files/Oracle/VirtualBox/VBoxManage.exe"
+elif [[ "$OSTYPE" == "msys" ]]; then
+		VBOXMANAGE="/c/Program Files/Oracle/VirtualBox/VBoxManage.exe"
+elif [[ "$OSTYPE" == "win32" ]]; then
+		VBOXMANAGE="/c/Program Files/Oracle/VirtualBox/VBoxManage.exe"
+elif [[ "$OSTYPE" == "freebsd"* ]]; then
+        VBOXMANAGE=`which vboxmanage`
+else
+        echo Seriously, what the hell are you running me on????
+		exit 1
+fi
+
+FILES=*.vagrantfile
+for f in $FILES
+do
+	echo Testing $f
+	VAGRANT_VAGRANTFILE="$f" vagrant up --no-color > $f.log
+	VAGRANT_VAGRANTFILE="$f" vagrant ssh -- "mount | grep -q mysql"
+	RESULT=$?
+	if [ $RESULT -eq 0 ]; then
+		echo ...[PASSED]
+	else
+		echo ...[FAILED]
+	fi
+	VAGRANT_VAGRANTFILE="$f" vagrant destroy -f --no-color >> $f.log && "$VBOXMANAGE" closemedium disk virtualdrive.vdi --delete >> $f.log 2>&1 
+done
+
+
+popd > /dev/null


### PR DESCRIPTION
So this pull request should now:

1. Add partition option
2. Fix validation of configuration options
3. Fix defaulting of configuration based on incorrect checking of empty (change of types messed this up)
4. Add a simple test.sh file that automates spinning up a few different Vagrant test files.  This still requires the gem to be built and installed (consider this a TODO that I did not have strong enough background in Ruby to fully automate).  This will spin up and tear down boxes and test them, simple single test set up at the moment but should be easy to extend.

It was a bit messy due to revert and other pulls coming in, but I think it is now in pretty good shape.

Let me know if any of it does not work/is unclear.

Regards,

Ben