### PR TITLE
Fix mysterious disk_operations_.sh not found errors

### DIFF
--- a/lib/vagrant-persistent-storage/manage_storage.rb
+++ b/lib/vagrant-persistent-storage/manage_storage.rb
@@ -130,7 +130,7 @@ exit $?
       def run_disk_operations(m)
         return unless m.communicate.ready?
         mnt_name = m.config.persistent_storage.mountname
-        mnt_name = 'vps' unless mnt_name != 0
+        mnt_name = 'vps' unless mnt_name != ""
 		if m.config.vm.communicator == :winrm
 			target_script = "disk_operations_#{mnt_name}.ps1"
 			m.communicate.sudo("powershell -executionpolicy bypass -file #{target_script}")


### PR DESCRIPTION
When trying to bring up my VMs with the latest version of the plugin I
kept getting errors that complained abouta file called
"/tmp/disk_operations_.sh" being missing. This looked like a
substitution failure to me so I started digging around.

As far as I can tell commit a30e340d5069c761845e2016550c877bd1497eae
changed the mnt_name variable from 0 to "" when invalid. The last
check for running the actual setup didn't get updated for this change
though.

This patch fixes my issues with bringing up my VMs.