### PR TITLE
Fix filesystem detection for non-LVM storage

### DIFF
--- a/lib/vagrant-persistent-storage/manage_storage.rb
+++ b/lib/vagrant-persistent-storage/manage_storage.rb
@@ -91,8 +91,8 @@ echo "vg activation returned:  $?" >> disk_operation_log.txt
 
 <% if format == true  %>
 # Create the filesytem if it doesn't already exist
-MNT_NAME=#{vg_name}-#{mnt_name}
-[[ `blkid | grep ${MNT_NAME:0:16} | grep #{fs_type}` ]] || mkfs.#{fs_type} -L #{mnt_name} #{device}
+MNT_NAME=#{mnt_name}
+[[ `blkid -t LABEL=${MNT_NAME:0:16} | grep #{fs_type}` ]] || mkfs.#{fs_type} -L #{mnt_name} #{device}
 echo "#{fs_type} creation return:  $?" >> disk_operation_log.txt
 <% if mount == true %>
 # Create mountpoint #{mnt_point}


### PR DESCRIPTION
If lvm is disabled, the disk operations script ends up always recreating the filesystem:

```bash
# Create the filesytem if it doesn't already exist
MNT_NAME=vps-aptcache
[[ `blkid | grep ${MNT_NAME:0:16} | grep ext4` ]] || mkfs.ext4 -L aptcache /dev/sdb1
echo "ext4 creation return:  $?" >> disk_operation_log.txt
```

As blkid returns the following:

```console
# blkid
/dev/sdb1: LABEL="aptcache" UUID="7cb9d396-3078-43a7-b414-e5219000914c" TYPE="ext4" PARTUUID="89cf2853-01"
/dev/sda1: UUID="87033200-d9d7-4e18-9cf7-6c2a6cd1836a" TYPE="ext4" PARTUUID="1972789d-01"
/dev/sda5: UUID="01d2eeb4-4753-482f-95aa-b2e58396d673" TYPE="swap" PARTUUID="1972789d-05"
```

blkid has a -t option which allows filtering results by label (and other things) - so I've switched to using that.