### PR TITLE
Plugin does not work with kitchen-vagrant

### DIFF
--- a/lib/vagrant-persistent-storage/config.rb
+++ b/lib/vagrant-persistent-storage/config.rb
@@ -37,7 +37,7 @@ module VagrantPlugins
         @manage = true
         @format = true
         @use_lvm = true
-        @enabled = false
+        @enabled = false if @enabled == UNSET_VALUE
         @partition = true
         @location = UNSET_VALUE
         @mountname = UNSET_VALUE
@@ -143,7 +143,7 @@ module VagrantPlugins
           errors << I18n.t('vagrant_persistent_storage.config.no_create_and_missing', {
             :config_key => 'persistent_storage.create',
             :is_path   => location.class.to_s,
-          })       
+          })
         end
 
         { 'Persistent Storage configuration' => errors }


### PR DESCRIPTION
    Gem kitchen-vagrant uses option vagrantfiles [0] to define other
    Vagrantfiles to be merged with default one. Under the hood it uses
    require on top of main Vagrantfile. When you configure persistent
    storage plugin in one of vagrantfiles [0] plugin will be disabled
    due to load order and merging [1].

    [0] https://github.com/test-kitchen/kitchen-vagrant#-vagrantfiles
    [1] https://www.vagrantup.com/docs/vagrantfile/#load-order