### PR TITLE
Ensure that already-formatted disks are mounted

### DIFF
--- a/lib/vagrant-persistent-storage/manage_storage.rb
+++ b/lib/vagrant-persistent-storage/manage_storage.rb
@@ -94,6 +94,7 @@ echo "vg activation returned:  $?" >> disk_operation_log.txt
 MNT_NAME=#{mnt_name}
 [[ `blkid -t LABEL=${MNT_NAME:0:16} | grep #{fs_type}` ]] || mkfs.#{fs_type} -L #{mnt_name} #{device}
 echo "#{fs_type} creation return:  $?" >> disk_operation_log.txt
+<% end %>
 <% if mount == true %>
 # Create mountpoint #{mnt_point}
 [ -d #{mnt_point} ] || mkdir -p #{mnt_point}
@@ -103,7 +104,6 @@ echo "fstab update returned:  $?" >> disk_operation_log.txt
 # Finally, mount the partition
 [[ `mount | grep #{mnt_point}` ]] || mount #{mnt_point}
 echo "#{mnt_point} mounting returned:  $?" >> disk_operation_log.txt
-<% end %>
 <% end %>
 exit $?
         EOF


### PR DESCRIPTION
Without this change, an already formatted disk is not mounted, even though the device is successfully added. This is because the `mount == true` test is embedded within the `format == true` test, so it never succeeds and that code is not added to the script that is injected into the VM.