### PR TITLE
Remove hardcoded /bin/bash path

### DIFF
--- a/lib/vagrant-persistent-storage/manage_storage.rb
+++ b/lib/vagrant-persistent-storage/manage_storage.rb
@@ -66,7 +66,7 @@ module VagrantPlugins
 		else
 		## shell script to format disk, create/manage LVM, mount disk
         disk_operations_template = ERB.new <<-EOF
-#!/bin/bash
+#!/usr/bin/env bash
 DISK_DEV=#{disk_dev}
 <% if partition == true %>
 # fdisk the disk if it's not a block device already:


### PR DESCRIPTION
Some systems (e.g., FreeBSD), don't have bash at /bin/bash. Use /usr/bin/env bash in the shebang line instead.