### PR TITLE
Allow passing arguments to storageattach

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ When you expect a lot of writes in the disk (the case for `/home` mountpoints) i
 config.persistent_storage.variant    = 'Fixed'
 ```
 
+If you want to pass a list of options to the underlying `VboxManage
+storageattach` call, you can use the `config.persistent_storage.attachoptions`
+option. For instance, if you want to enable TRIM support:
+
+```ruby
+config.persistent_storage.mountoptions = ['defaults', 'discard']
+config.persistent_storage.attachoptions = ['--discard', 'on']
+```
+
 Every `vagrant up` will attach this file as hard disk to the guest machine.
 A `vagrant destroy` will detach the storage to avoid deletion of the storage by vagrant.
 A `vagrant destroy` generally destroys all attached drives. See [VBoxManage unregistervm --delete option][vboxmanage_delete].

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ config.persistent_storage.mountpoint = '/var/lib/mysql'
 config.persistent_storage.volgroupname = 'myvolgroup'
 ```
 
-With `config.persistent_storage.mountoptions` you can change the mount options (default: defaults).  
+With `config.persistent_storage.mountoptions` you can change the mount options (default: defaults).
 An example which sets `prjquota` option with xfs.
 ```ruby
 config.persistent_storage.mountname    = 'xfs'
@@ -52,13 +52,13 @@ Every `vagrant up` will attach this file as hard disk to the guest machine.
 A `vagrant destroy` will detach the storage to avoid deletion of the storage by vagrant.
 A `vagrant destroy` generally destroys all attached drives. See [VBoxManage unregistervm --delete option][vboxmanage_delete].
 
-The disk is initialized and added to it's own volume group as specfied in the config; 
+The disk is initialized and added to it's own volume group as specfied in the config;
 this defaults to 'vagrant'. An ext4 filesystem is created and the disk mounted appropriately,
 with entries added to fstab ... subsequent runs will mount this disk with the options specified.
 
 ## Windows Guests
 
-Windows Guests must use the WinRM communicator by setting `vm.communicator = 'winrm'`.  An additional option is provided to 
+Windows Guests must use the WinRM communicator by setting `vm.communicator = 'winrm'`.  An additional option is provided to
 allow you to set the drive letter using:
 
 ```ruby

--- a/lib/vagrant-persistent-storage/action/attach_storage.rb
+++ b/lib/vagrant-persistent-storage/action/attach_storage.rb
@@ -24,7 +24,8 @@ module VagrantPlugins
 
           env[:ui].info I18n.t("vagrant_persistent_storage.action.attach_storage")
           location = env[:machine].config.persistent_storage.location
-          env[:machine].provider.driver.attach_storage(location)
+          attachoptions = env[:machine].config.persistent_storage.attachoptions
+          env[:machine].provider.driver.attach_storage(location, attachoptions)
 
           @app.call(env)
 

--- a/lib/vagrant-persistent-storage/config.rb
+++ b/lib/vagrant-persistent-storage/config.rb
@@ -17,6 +17,7 @@ module VagrantPlugins
       attr_accessor :mountname
       attr_accessor :mountpoint
       attr_accessor :mountoptions
+      attr_accessor :attachoptions
       attr_accessor :partition
       attr_accessor :diskdevice
       attr_accessor :filesystem
@@ -46,6 +47,7 @@ module VagrantPlugins
         @mountname = UNSET_VALUE
         @mountpoint = UNSET_VALUE
         @mountoptions = UNSET_VALUE
+        @attachoptions = UNSET_VALUE
         @diskdevice = UNSET_VALUE
         @filesystem = UNSET_VALUE
         @volgroupname = UNSET_VALUE
@@ -68,6 +70,7 @@ module VagrantPlugins
         @mountname = "" if @mountname == UNSET_VALUE
         @mountpoint = "" if @mountpoint == UNSET_VALUE
         @mountoptions = [] if @mountoptions == UNSET_VALUE
+        @attachoptions = [] if @attachoptions == UNSET_VALUE
         @diskdevice = "" if @diskdevice == UNSET_VALUE
         @filesystem = "" if @filesystem == UNSET_VALUE
         @volgroupname = "" if @volgroupname == UNSET_VALUE

--- a/lib/vagrant-persistent-storage/providers/virtualbox/driver/base.rb
+++ b/lib/vagrant-persistent-storage/providers/virtualbox/driver/base.rb
@@ -15,7 +15,7 @@ module VagrantPlugins
             execute("storagectl", @uuid, "--name", controller_name, "--" + (self.remove_prefix(@version) ? "" : "sata") + "portcount", "2")
           end
         end
-        
+
         def remove_prefix(vbox_version)
            return vbox_version.start_with?("4.3") || vbox_version.start_with?("5.") || vbox_version.start_with?("6.")
         end
@@ -122,4 +122,3 @@ module VagrantPlugins
     end
   end
 end
-

--- a/lib/vagrant-persistent-storage/providers/virtualbox/driver/base.rb
+++ b/lib/vagrant-persistent-storage/providers/virtualbox/driver/base.rb
@@ -24,7 +24,7 @@ module VagrantPlugins
           execute("createhd", "--filename", File.expand_path(location), "--size", "#{size}", "--variant", "#{variant}")
         end
 
-        def attach_storage(location)
+        def attach_storage(location, attachoptions)
           controller_name = get_controller_name
           if controller_name.nil?
             controller_name = "SATA Controller"
@@ -32,15 +32,15 @@ module VagrantPlugins
 
           location_realpath = File.expand_path(location)
 
+          base_cmd = ["storageattach", @uuid, "--storagectl", get_controller_name, "--type", "hdd", "--medium", "#{location_realpath}"]
           if controller_name.start_with?("IDE")
-              execute("storageattach", @uuid, "--storagectl", get_controller_name, "--port", "1", "--device", "0", "--type", "hdd", "--medium", "#{location_realpath}")
+              ctrl_args = ["--port", "1", "--device", "0"]
           elsif controller_name.start_with?("SCSI")
-              execute("storageattach", @uuid, "--storagectl", get_controller_name, "--port", "15", "--device", "0", "--type", "hdd", "--medium", "#{location_realpath}")
+              ctrl_args = ["--port", "15", "--device", "0"]
           else
-              execute("storageattach", @uuid, "--storagectl", get_controller_name, "--port", "4", "--device", "0", "--type", "hdd", "--medium", "#{location_realpath}", "--hotpluggable", "on")
+              ctrl_args = ["--port", "4", "--device", "0", "--hotpluggable", "on"]
           end
-
-
+          execute(*(base_cmd + ctrl_args + attachoptions))
         end
 
         def detach_storage(location)


### PR DESCRIPTION
Add a `config.persistent_storage.attachoptions` config variable that
allows the user to pass any option they want to the `VBoxManage
storageattach` call.
    
A use case for this config variable is enabling TRIM support.
