### PR TITLE
Fix sata storage flag for Virtualbox 7.x

### DIFF
--- a/lib/vagrant-persistent-storage/providers/virtualbox/driver/base.rb
+++ b/lib/vagrant-persistent-storage/providers/virtualbox/driver/base.rb
@@ -17,7 +17,7 @@ module VagrantPlugins
         end
 
         def remove_prefix(vbox_version)
-           return vbox_version.start_with?("4.3") || vbox_version.start_with?("5.") || vbox_version.start_with?("6.")
+           return vbox_version.start_with?("4.3") || vbox_version.start_with?("5.") || vbox_version.start_with?("6.")|| vbox_version.start_with?("7.")
         end
 
         def create_storage(location, size, variant)


### PR DESCRIPTION
Mounting a persistent volume to a Vagrant box built with the Virtualbox 7 provider results in the error `Unknown option: --sataportcount`. The command line flag for specifying a port count should be just `--portcount` in Virtualbox 7 as in Virtualbox 6. This modification makes the behavior consistent between Virtualbox 6 and 7.